### PR TITLE
Remove win32-ia32 from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
             npm_config_arch: x64
           - os: windows-latest
             platform: win32
-            arch: ia32
-            npm_config_arch: ia32
-          - os: windows-latest
-            platform: win32
             arch: arm64
             npm_config_arch: arm
           - os: ubuntu-latest


### PR DESCRIPTION
@joaomoreno I believe you missed this in https://github.com/microsoft/vscode-platform-specific-sample/pull/10.