### PR TITLE
Add alpine-arm64 platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
             platform: alpine
             arch: x64
             npm_config_arch: x64
+          - os: ubuntu-latest
+            platform: alpine
+            arch: arm64
+            npm_config_arch: arm64
           - os: macos-latest
             platform: darwin
             arch: x64


### PR DESCRIPTION
This platform is present in the documentation:

https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions

But was missing from the example.

@joaomoreno, I'd say this PR is a no-brainer.